### PR TITLE
feat: OpenID Connect for Self Hosted Instance with God-Mode Implementation

### DIFF
--- a/apiserver/.env.example
+++ b/apiserver/.env.example
@@ -58,6 +58,17 @@ ENABLE_EMAIL_PASSWORD="1"
 # Enable Magic link Login
 ENABLE_MAGIC_LINK_LOGIN="0"
 
+# Enable OpenID Connect Login - You can set the Issuer to get the Enpoints (URLs) automatically or set them manually
+# If you set the Endpoints manually the issuer should be empty to avoid overriding the endpoints
+OIDC_AUTO="0"
+OIDC_CLIENT_ID=""
+OIDC_CLIENT_SECRET=""
+OIDC_ISSUER=""
+OIDC_URL_AUTHORIZATION=""
+OIDC_URL_TOKEN=""
+OIDC_URL_USERINFO=""
+OIDC_URL_ENDSESSION=""
+
 # Email redirections and minio domain settings
 WEB_URL="http://localhost"
 

--- a/apiserver/plane/app/urls/authentication.py
+++ b/apiserver/plane/app/urls/authentication.py
@@ -10,6 +10,7 @@ from plane.app.views import (
     MagicGenerateEndpoint,
     MagicSignInEndpoint,
     OauthEndpoint,
+    OIDCEndpoint,
     EmailCheckEndpoint,
     ## End Authentication
     # Auth Extended
@@ -27,6 +28,7 @@ urlpatterns = [
     #  Social Auth
     path("email-check/", EmailCheckEndpoint.as_view(), name="email"),
     path("social-auth/", OauthEndpoint.as_view(), name="oauth"),
+    path("oidc-auth/", OIDCEndpoint.as_view(), name="oidc"),
     # Auth
     path("sign-in/", SignInEndpoint.as_view(), name="sign-in"),
     path("sign-out/", SignOutEndpoint.as_view(), name="sign-out"),

--- a/apiserver/plane/app/views/__init__.py
+++ b/apiserver/plane/app/views/__init__.py
@@ -22,6 +22,8 @@ from .user import (
 
 from .oauth import OauthEndpoint
 
+from .oidc import OIDCEndpoint
+
 from .base import BaseAPIView, BaseViewSet, WebhookMixin
 
 from .workspace import (

--- a/apiserver/plane/app/views/config.py
+++ b/apiserver/plane/app/views/config.py
@@ -132,7 +132,11 @@ class ConfigurationEndpoint(BaseAPIView):
         )
         data["github_app_name"] = GITHUB_APP_NAME
         data["oidc_auto"] = (
-            bool(OIDC_CLIENT_ID) and bool(OIDC_CLIENT_SECRET) and bool(OIDC_URL_AUTHORIZATION) and bool(OIDC_URL_TOKEN) and bool(OIDC_URL_USERINFO)
+            bool(OIDC_CLIENT_ID) and 
+            bool(OIDC_CLIENT_SECRET) and 
+            bool(OIDC_URL_AUTHORIZATION) and 
+            bool(OIDC_URL_TOKEN) and 
+            bool(OIDC_URL_USERINFO)
         ) and OIDC_AUTO == "1"
         data["oidc_client_id"] = (
             OIDC_CLIENT_ID if OIDC_CLIENT_ID and OIDC_CLIENT_ID != '""' else None

--- a/apiserver/plane/app/views/config.py
+++ b/apiserver/plane/app/views/config.py
@@ -25,6 +25,13 @@ class ConfigurationEndpoint(BaseAPIView):
             GOOGLE_CLIENT_ID,
             GITHUB_CLIENT_ID,
             GITHUB_APP_NAME,
+            OIDC_AUTO,
+            OIDC_CLIENT_ID,
+            OIDC_CLIENT_SECRET,
+            OIDC_URL_AUTHORIZATION,
+            OIDC_URL_TOKEN,
+            OIDC_URL_USERINFO,
+            OIDC_URL_ENDSESSION,
             EMAIL_HOST_USER,
             EMAIL_HOST_PASSWORD,
             ENABLE_MAGIC_LINK_LOGIN,
@@ -47,6 +54,34 @@ class ConfigurationEndpoint(BaseAPIView):
                 {
                     "key": "GITHUB_APP_NAME",
                     "default": os.environ.get("GITHUB_APP_NAME", None),
+                },
+                {
+                    "key": "OIDC_AUTO",
+                    "default": os.environ.get("OIDC_AUTO", None),
+                },
+                {
+                    "key": "OIDC_CLIENT_ID",
+                    "default": os.environ.get("OIDC_CLIENT_ID", None),
+                },
+                {
+                    "key": "OIDC_CLIENT_SECRET",
+                    "default": os.environ.get("OIDC_CLIENT_SECRET", None),
+                },
+                {
+                    "key": "OIDC_URL_AUTHORIZATION",
+                    "default": os.environ.get("OIDC_URL_AUTHORIZATION", None),
+                },
+                {
+                    "key": "OIDC_URL_TOKEN",
+                    "default": os.environ.get("OIDC_URL_TOKEN", None),
+                },
+                {
+                    "key": "OIDC_URL_USERINFO",
+                    "default": os.environ.get("OIDC_URL_USERINFO", None),
+                },
+                {
+                    "key": "OIDC_URL_ENDSESSION",
+                    "default": os.environ.get("OIDC_URL_ENDSESSION", None),
                 },
                 {
                     "key": "EMAIL_HOST_USER",
@@ -96,6 +131,14 @@ class ConfigurationEndpoint(BaseAPIView):
             GITHUB_CLIENT_ID if GITHUB_CLIENT_ID and GITHUB_CLIENT_ID != '""' else None
         )
         data["github_app_name"] = GITHUB_APP_NAME
+        data["oidc_auto"] = (
+            bool(OIDC_CLIENT_ID) and bool(OIDC_CLIENT_SECRET) and bool(OIDC_URL_AUTHORIZATION) and bool(OIDC_URL_TOKEN) and bool(OIDC_URL_USERINFO)
+        ) and OIDC_AUTO == "1"
+        data["oidc_client_id"] = (
+            OIDC_CLIENT_ID if OIDC_CLIENT_ID and OIDC_CLIENT_ID != '""' else None
+        )
+        data["oidc_url_authorize"] = OIDC_URL_AUTHORIZATION
+        data["oidc_url_endsession"] = OIDC_URL_ENDSESSION
         data["magic_login"] = (
             bool(EMAIL_HOST_USER) and bool(EMAIL_HOST_PASSWORD)
         ) and ENABLE_MAGIC_LINK_LOGIN == "1"

--- a/apiserver/plane/app/views/oidc.py
+++ b/apiserver/plane/app/views/oidc.py
@@ -1,0 +1,488 @@
+# Python imports
+from base64 import b64encode
+import uuid
+import requests
+import os
+
+# Django imports
+from django.utils import timezone
+from django.conf import settings
+
+# Third Party modules
+from rest_framework.response import Response
+from rest_framework import exceptions
+from rest_framework.permissions import AllowAny
+from rest_framework.views import APIView
+from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework import status
+from sentry_sdk import capture_exception
+
+# Module imports
+from plane.db.models import (
+    SocialLoginConnection,
+    User,
+    WorkspaceMemberInvite,
+    WorkspaceMember,
+    ProjectMemberInvite,
+    ProjectMember,
+)
+from plane.bgtasks.event_tracking_task import auth_events
+from .base import BaseAPIView
+from plane.license.models import Instance
+from plane.license.utils.instance_value import get_configuration_value
+
+def get_endpoint_information(issuer: str):
+    # Make a GET request to the url issuer/.well-known/openid-configuration
+    # Get the properties of authorization_endpoint, token_endpoint, userinfo_endpoint, end_session_endpoint
+    # Return them in a tuple
+    # If any of the endpoints are not present, raise an exception
+    # If the response is not a JSON, raise an exception
+    # If the response is not a valid JSON, raise an exception
+
+    if not issuer:
+        raise ValueError("The issuer has to be supplied!")
+    if not isinstance(issuer, str):
+        raise ValueError("The issuer has to be a string!")
+
+    url = issuer + "/.well-known/openid-configuration"
+    response = requests.get(url=url)
+    data = response.json()
+
+    authorization_endpoint = data.get("authorization_endpoint", None)
+    token_endpoint = data.get("token_endpoint", None)
+    userinfo_endpoint = data.get("userinfo_endpoint", None)
+    end_session_endpoint = data.get("end_session_endpoint", None)
+
+    if (
+        authorization_endpoint is None
+        or token_endpoint is None
+        or userinfo_endpoint is None
+        or end_session_endpoint is None
+    ):
+        raise ValueError("The response does not contain all the endpoints!")
+
+    return (
+        authorization_endpoint,
+        token_endpoint,
+        userinfo_endpoint,
+        end_session_endpoint,
+    )
+
+def get_tokens_for_user(user):
+    refresh = RefreshToken.for_user(user)
+    return (
+        str(refresh.access_token),
+        str(refresh),
+    )
+
+
+def get_access_token(request_token: str, client_id: str) -> str:
+    """Obtain the request token from OIDC Provider.
+    Given the client id, client secret and request issued out by the OIDC Provider, this method
+    should give back an access token
+    Parameters
+    ----------
+    CLIENT_ID: str
+        A string representing the client id issued out by the OIDC Provider
+    CLIENT_SECRET: str
+        A string representing the client secret issued out by the OIDC Provider
+    request_token: str
+        A string representing the request token issued out by the OIDC Provider
+    Throws
+    ------
+    ValueError:
+        if CLIENT_ID or CLIENT_SECRET or request_token is empty or not a string
+    Returns
+    -------
+    access_token: str
+        A string representing the access token issued out by the OIDC Provider
+    """
+
+    if not request_token:
+        raise ValueError("The request token has to be supplied!")
+
+    (ACCESS_TOKEN_URL, CLIENT_SECRET,) = get_configuration_value(
+        [
+            {
+                "key": "OIDC_URL_TOKEN",
+                "default": os.environ.get("OIDC_URL_TOKEN", None),
+            },
+            {
+                "key": "OIDC_CLIENT_SECRET",
+                "default": os.environ.get("OIDC_CLIENT_SECRET", None),
+            },
+        ]
+    )
+
+    url = f"{ACCESS_TOKEN_URL}"
+    data = {
+        "grant_type": "authorization_code",
+        "code": request_token,
+        "redirect_uri": "http://localhost:8090/",
+    }
+    basic_auth = b64encode(f"{client_id}:{CLIENT_SECRET}".encode('utf-8')).decode("ascii")
+    headers = {
+        "accept": "application/json", 
+        "content-type": "application/x-www-form-urlencoded", 
+        "Authorization": "Basic " + basic_auth,
+    }
+
+    res = requests.post(url, headers=headers, data=data)
+    
+    data = res.json()
+    print(data)
+    access_token = data["access_token"]
+
+    return access_token
+
+
+def get_user_data(access_token: str) -> dict:
+    """
+    Obtain the user data from OIDC Provider.
+    Given the access token, this method should give back the user data
+    """
+    if not access_token:
+        raise ValueError("The request token has to be supplied!")
+    if not isinstance(access_token, str):
+        raise ValueError("The request token has to be a string!")
+
+    (USERINFO_URL,) = get_configuration_value(
+        [
+            {
+                "key": "OIDC_URL_USERINFO",
+                "default": os.environ.get("OIDC_URL_USERINFO", None),
+            },
+        ]
+    )
+
+    access_token = "Bearer " + access_token
+    headers = {"Authorization": access_token}
+
+    response = requests.get(url=USERINFO_URL, headers=headers)
+
+    user_data = response.json()
+
+    return user_data
+
+
+class OIDCEndpoint(BaseAPIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        try:
+            # Check if instance is registered or not
+            instance = Instance.objects.first()
+            if instance is None and not instance.is_setup_done:
+                return Response(
+                    {"error": "Instance is not configured"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            
+            id_token = request.data.get("credential", False)
+            client_id = request.data.get("clientId", False)
+            medium = "oidc"
+
+            OIDC_CLIENT_ID = get_configuration_value(
+                [
+                    {
+                        "key": "OIDC_CLIENT_ID",
+                        "default": os.environ.get("OIDC_CLIENT_ID"),
+                    }
+                ]
+            )
+
+            if not id_token:
+                return Response(
+                    {
+                        "error": "Something went wrong. Please try again later or contact the support team. No ID Token found."
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            if not OIDC_CLIENT_ID:
+                return Response(
+                        {"error": "OpenID Connect login is not configured"},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+
+            access_token = get_access_token(id_token, client_id)
+            data = get_user_data(access_token)
+
+            email = data.get("email", None)
+            if email == None:
+                return Response(
+                    {
+                        "error": "Something went wrong. Please try again later or contact the support team. No email found."
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            if "@" in email:
+                user = User.objects.get(email=email)
+                email = data["email"]
+                mobile_number = uuid.uuid4().hex
+                email_verified = True
+            else:
+                return Response(
+                    {
+                        "error": "Something went wrong. Please try again later or contact the support team. No valid email found. Existing User."
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            ## Login Case
+
+            if not user.is_active:
+                return Response(
+                    {
+                        "error": "Your account has been deactivated. Please contact your site administrator."
+                    },
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+
+            user.last_active = timezone.now()
+            user.last_login_time = timezone.now()
+            user.last_login_ip = request.META.get("REMOTE_ADDR")
+            user.last_login_medium = medium
+            user.last_login_uagent = request.META.get("HTTP_USER_AGENT")
+            user.is_email_verified = email_verified
+            user.save()
+
+            # Check if user has any accepted invites for workspace and add them to workspace
+            workspace_member_invites = WorkspaceMemberInvite.objects.filter(
+                email=user.email, accepted=True
+            )
+
+            WorkspaceMember.objects.bulk_create(
+                [
+                    WorkspaceMember(
+                        workspace_id=workspace_member_invite.workspace_id,
+                        member=user,
+                        role=workspace_member_invite.role,
+                    )
+                    for workspace_member_invite in workspace_member_invites
+                ],
+                ignore_conflicts=True,
+            )
+
+            # Check if user has any project invites
+            project_member_invites = ProjectMemberInvite.objects.filter(
+                email=user.email, accepted=True
+            )
+
+            # Add user to workspace
+            WorkspaceMember.objects.bulk_create(
+                [
+                    WorkspaceMember(
+                        workspace_id=project_member_invite.workspace_id,
+                        role=project_member_invite.role
+                        if project_member_invite.role in [5, 10, 15]
+                        else 15,
+                        member=user,
+                        created_by_id=project_member_invite.created_by_id,
+                    )
+                    for project_member_invite in project_member_invites
+                ],
+                ignore_conflicts=True,
+            )
+
+            # Now add the users to project
+            ProjectMember.objects.bulk_create(
+                [
+                    ProjectMember(
+                        workspace_id=project_member_invite.workspace_id,
+                        role=project_member_invite.role
+                        if project_member_invite.role in [5, 10, 15]
+                        else 15,
+                        member=user,
+                        created_by_id=project_member_invite.created_by_id,
+                    )
+                    for project_member_invite in project_member_invites
+                ],
+                ignore_conflicts=True,
+            )
+            # Delete all the invites
+            workspace_member_invites.delete()
+            project_member_invites.delete()
+
+            SocialLoginConnection.objects.update_or_create(
+                medium=medium,
+                extra_data={},
+                user=user,
+                defaults={
+                    "token_data": {"id_token": id_token},
+                    "last_login_at": timezone.now(),
+                },
+            )
+
+            # Send event
+            auth_events.delay(
+                user=user.id,
+                email=email,
+                user_agent=request.META.get("HTTP_USER_AGENT"),
+                ip=request.META.get("REMOTE_ADDR"),
+                event_name="SIGN_IN",
+                medium=medium.upper(),
+                first_time=False,
+            )
+            
+            access_token, refresh_token = get_tokens_for_user(user)
+
+            data = {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+            }
+
+            return Response(data, status=status.HTTP_200_OK)
+
+        except User.DoesNotExist:
+            ## Signup Case
+            (ENABLE_SIGNUP,) = get_configuration_value(
+                [
+                    {
+                        "key": "ENABLE_SIGNUP",
+                        "default": os.environ.get("ENABLE_SIGNUP", "0"),
+                    }
+                ]
+            )
+            if (
+                ENABLE_SIGNUP == "0"
+                and not WorkspaceMemberInvite.objects.filter(
+                    email=email,
+                ).exists()
+            ):
+                return Response(
+                    {
+                        "error": "New account creation is disabled. Please contact your site administrator"
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            username = data.get("preferred_username", uuid.uuid4().hex)
+            display_name = data.get("name", uuid.uuid4().hex)
+                
+            if "@" in email:
+                email = data["email"]
+                mobile_number = uuid.uuid4().hex
+                email_verified = True
+            else:
+                return Response(
+                    {
+                        "error": "Something went wrong. Please try again later or contact the support team. E-Mail not valid. New User."
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            user = User.objects.create(
+                username=username,
+                display_name=display_name,
+                email=email,
+                mobile_number=mobile_number,
+                first_name=data.get("given_name", ""),
+                last_name=data.get("family_name", ""),
+                is_email_verified=email_verified,
+                is_password_autoset=True,
+            )
+
+            user.set_password(uuid.uuid4().hex)
+            user.last_active = timezone.now()
+            user.last_login_time = timezone.now()
+            user.last_login_ip = request.META.get("REMOTE_ADDR")
+            user.last_login_medium = medium
+            user.last_login_uagent = request.META.get("HTTP_USER_AGENT")
+            user.token_updated_at = timezone.now()
+            user.save()
+
+            # Check if user has any accepted invites for workspace and add them to workspace
+            workspace_member_invites = WorkspaceMemberInvite.objects.filter(
+                email=user.email, accepted=True
+            )
+
+            WorkspaceMember.objects.bulk_create(
+                [
+                    WorkspaceMember(
+                        workspace_id=workspace_member_invite.workspace_id,
+                        member=user,
+                        role=workspace_member_invite.role,
+                    )
+                    for workspace_member_invite in workspace_member_invites
+                ],
+                ignore_conflicts=True,
+            )
+
+            # Check if user has any project invites
+            project_member_invites = ProjectMemberInvite.objects.filter(
+                email=user.email, accepted=True
+            )
+
+            # Add user to workspace
+            WorkspaceMember.objects.bulk_create(
+                [
+                    WorkspaceMember(
+                        workspace_id=project_member_invite.workspace_id,
+                        role=project_member_invite.role
+                        if project_member_invite.role in [5, 10, 15]
+                        else 15,
+                        member=user,
+                        created_by_id=project_member_invite.created_by_id,
+                    )
+                    for project_member_invite in project_member_invites
+                ],
+                ignore_conflicts=True,
+            )
+
+            # Now add the users to project
+            ProjectMember.objects.bulk_create(
+                [
+                    ProjectMember(
+                        workspace_id=project_member_invite.workspace_id,
+                        role=project_member_invite.role
+                        if project_member_invite.role in [5, 10, 15]
+                        else 15,
+                        member=user,
+                        created_by_id=project_member_invite.created_by_id,
+                    )
+                    for project_member_invite in project_member_invites
+                ],
+                ignore_conflicts=True,
+            )
+            # Delete all the invites
+            workspace_member_invites.delete()
+            project_member_invites.delete()
+
+            # Send event
+            auth_events.delay(
+                user=user.id,
+                email=email,
+                user_agent=request.META.get("HTTP_USER_AGENT"),
+                ip=request.META.get("REMOTE_ADDR"),
+                event_name="SIGN_IN",
+                medium=medium.upper(),
+                first_time=True,
+            )
+
+            SocialLoginConnection.objects.update_or_create(
+                medium=medium,
+                extra_data={},
+                user=user,
+                defaults={
+                    "token_data": {"id_token": id_token},
+                    "last_login_at": timezone.now(),
+                },
+            )
+
+            access_token, refresh_token = get_tokens_for_user(user)
+            data = {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+            }
+
+            return Response(data, status=status.HTTP_201_CREATED)
+        except Exception as e:
+            capture_exception(e)
+            return Response(
+                {
+                    "error": "Something went wrong. Please try again later or contact the support team." + str(e)
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )

--- a/apiserver/plane/license/management/commands/configure_instance.py
+++ b/apiserver/plane/license/management/commands/configure_instance.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from plane.license.models import InstanceConfiguration
 from plane.app.views.oidc import get_endpoint_information
 
+
 class Command(BaseCommand):
     help = "Configure instance variables"
 
@@ -162,7 +163,12 @@ class Command(BaseCommand):
         # Autodiscovery of Settings for OIDC based on the OIDC_ISSUER
         for item in config_keys:
             if item.get("key") == "OIDC_ISSUER" and item.get("value"):
-                (OIDC_URL_AUTHORIZATION, OIDC_URL_TOKEN, OIDC_URL_USERINFO, OIDC_URL_ENDSESSION) = get_endpoint_information(item.get("value"))
+                (
+                    OIDC_URL_AUTHORIZATION, 
+                    OIDC_URL_TOKEN, 
+                    OIDC_URL_USERINFO, 
+                    OIDC_URL_ENDSESSION
+                ) = get_endpoint_information(item.get("value"))
                 issuerIndex = config_keys.index(item)
                 config_keys[issuerIndex + 3]["value"] = OIDC_URL_AUTHORIZATION
                 config_keys[issuerIndex + 4]["value"] = OIDC_URL_TOKEN

--- a/deploy/selfhost/variables.env
+++ b/deploy/selfhost/variables.env
@@ -49,6 +49,16 @@ ENABLE_SIGNUP=1
 ENABLE_EMAIL_PASSWORD=1
 ENABLE_MAGIC_LINK_LOGIN=0
 SECRET_KEY=60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5
+# Enable OpenID Connect Login - You can set the Issuer to get the Enpoints (URLs) automatically or set them manually
+# If you set the Endpoints manually the issuer should be empty to avoid overriding the endpoints
+OIDC_AUTO=0
+OIDC_CLIENT_ID=
+OIDC_CLIENT_SECRET=
+OIDC_ISSUER=
+OIDC_URL_AUTHORIZATION=
+OIDC_URL_TOKEN=
+OIDC_URL_USERINFO=
+OIDC_URL_ENDSESSION=
 
 # DATA STORE SETTINGS
 USE_MINIO=1

--- a/packages/types/src/app.d.ts
+++ b/packages/types/src/app.d.ts
@@ -4,6 +4,10 @@ export interface IAppConfig {
   google_client_id: string | null;
   github_app_name: string | null;
   github_client_id: string | null;
+  oidc_auto: boolean;
+  oidc_client_id: string | null;
+  oidc_url_authorize: string | null;
+  oidc_url_endsession: string | null;
   magic_login: boolean;
   slack_client_id: string | null;
   posthog_api_key: string | null;

--- a/web/components/account/oidc-sign-in.tsx
+++ b/web/components/account/oidc-sign-in.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState, FC } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { useRouter } from "next/router";
+// images
+import userImage from "/public/user.png";
+import { Spinner } from "@plane/ui";
+import { useTheme } from "next-themes";
+import useToast from "hooks/use-toast";
+import { AuthService } from "services/auth.service";
+
+export interface OidcSignInButtonProps {
+  handleSignInRedirection: () => Promise<void>;
+  autoRedirect: boolean;
+  clientId: string;
+  authUrl: string;
+}
+
+// services
+const authService = new AuthService();
+
+export const OidcSignInButton: FC<OidcSignInButtonProps> = (props) => {
+  const { handleSignInRedirection, autoRedirect, clientId, authUrl } = props;
+  // router
+  const {
+    push: routerPush,
+    query: { code },
+  } = useRouter();
+  // states
+  const [loginCallBackURL, setSignInCallBackURL] = useState(undefined);
+  const [oidcCode, setOidcCode] = useState<null | string>(null);
+  const [initialSignInError, setInitialSignInError] = useState<boolean>(false);
+  // theme
+  const { resolvedTheme } = useTheme();
+  // toast alert
+  const { setToastAlert } = useToast();
+
+  const handleOidcSignIn = async (credential: string) => {
+    try {
+      if (clientId && credential) {
+        const oidcAuthPayload = {
+          credential,
+          clientId,
+        };
+        const response = await authService.oidcAuth(oidcAuthPayload);
+
+        if (response) handleSignInRedirection();
+      } else throw Error("Cant find credentials");
+    } catch (err: any) {
+      setOidcCode(null);
+      setInitialSignInError(true);
+      setToastAlert({
+        title: "Error signing in!",
+        type: "error",
+        message: err?.error || "Something went wrong. Please try again later or contact the support team.",
+      });
+    }
+  };
+
+  const oidcRedirect = `${authUrl}?client_id=${clientId}&redirect_uri=${loginCallBackURL}&scope=openid%20profile%20email&response_type=code`;
+
+  useEffect(() => {
+    if (code && !oidcCode) {
+      setOidcCode(code.toString());
+      handleOidcSignIn(code.toString());
+    }
+    if (autoRedirect && (!code || !oidcCode) && loginCallBackURL && !initialSignInError) {
+      routerPush(oidcRedirect);
+    }
+  }, [loginCallBackURL, code, oidcCode, autoRedirect, oidcRedirect, initialSignInError]);
+
+  useEffect(() => {
+    const origin = typeof window !== "undefined" && window.location.origin ? window.location.origin : "";
+    setSignInCallBackURL(`${origin}/` as any);
+  }, []);
+
+  return (
+    <div className="w-full">
+      <Link href={oidcRedirect}>
+        <button
+          className={`flex h-[42px] w-full items-center justify-center gap-2 rounded border px-2 text-sm font-medium text-custom-text-100 duration-300 hover:bg-onboarding-background-300 ${
+            resolvedTheme === "dark" ? "border-[#43484F] bg-[#2F3135]" : "border-[#D9E4FF]"
+          }`}
+        >
+          {(autoRedirect && !initialSignInError) || code ? (
+            <Spinner />
+          ) : (
+            <>
+              <Image src={userImage} height={22} width={22} color="#000" alt="OIDC" />
+              <span className="text-onboarding-text-200">Sign In with OIDC</span>
+            </>
+          )}
+        </button>
+      </Link>
+    </div>
+  );
+};

--- a/web/components/account/oidc-sign-in.tsx
+++ b/web/components/account/oidc-sign-in.tsx
@@ -27,7 +27,7 @@ export const OidcSignInButton: FC<OidcSignInButtonProps> = (props) => {
     query: { code },
   } = useRouter();
   // states
-  const [loginCallBackURL, setSignInCallBackURL] = useState(undefined);
+  const [loginCallBackURL, setSignInCallBackURL] = useState<null | string>(null);
   const [oidcCode, setOidcCode] = useState<null | string>(null);
   const [initialSignInError, setInitialSignInError] = useState<boolean>(false);
   // theme
@@ -71,7 +71,7 @@ export const OidcSignInButton: FC<OidcSignInButtonProps> = (props) => {
 
   useEffect(() => {
     const origin = typeof window !== "undefined" && window.location.origin ? window.location.origin : "";
-    setSignInCallBackURL(`${origin}/` as any);
+    setSignInCallBackURL(`${origin}/`);
   }, []);
 
   return (

--- a/web/components/account/sign-in-forms/o-auth-options.tsx
+++ b/web/components/account/sign-in-forms/o-auth-options.tsx
@@ -6,6 +6,7 @@ import { useApplication } from "hooks/store";
 import useToast from "hooks/use-toast";
 // components
 import { GitHubSignInButton, GoogleSignInButton } from "components/account";
+import { OidcSignInButton } from "../oidc-sign-in";
 
 type Props = {
   handleSignInRedirection: () => Promise<void>;
@@ -69,7 +70,9 @@ export const OAuthOptions: React.FC<Props> = observer((props) => {
     <>
       <div className="mx-auto mt-4 flex items-center sm:w-96">
         <hr className="w-full border-onboarding-border-100" />
-        <p className="mx-3 flex-shrink-0 text-center text-sm text-onboarding-text-400">Or continue with</p>
+        <p className="mx-3 flex-shrink-0 text-center text-sm text-onboarding-text-400">
+          {envConfig?.oidc_auto ? "Automatically signing you in via OIDC" : "Or continue with"}
+        </p>
         <hr className="w-full border-onboarding-border-100" />
       </div>
       <div className="mx-auto mt-7 space-y-4 overflow-hidden sm:w-96">
@@ -78,6 +81,14 @@ export const OAuthOptions: React.FC<Props> = observer((props) => {
         )}
         {envConfig?.github_client_id && (
           <GitHubSignInButton clientId={envConfig?.github_client_id} handleSignIn={handleGitHubSignIn} />
+        )}
+        {envConfig?.oidc_client_id && envConfig?.oidc_url_authorize && (
+          <OidcSignInButton
+            autoRedirect={envConfig?.oidc_auto}
+            clientId={envConfig?.oidc_client_id}
+            authUrl={envConfig?.oidc_url_authorize}
+            handleSignInRedirection={handleSignInRedirection}
+          />
         )}
       </div>
     </>

--- a/web/components/account/sign-in-forms/root.tsx
+++ b/web/components/account/sign-in-forms/root.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { observer } from "mobx-react-lite";
 // hooks
-import { useApplication } from "hooks/store";
 import useSignInRedirection from "hooks/use-sign-in-redirection";
 // components
 import { LatestFeatureBlock } from "components/common";
@@ -14,6 +13,7 @@ import {
   OptionalSetPasswordForm,
   CreatePasswordForm,
 } from "components/account";
+import { useApplication } from "hooks/store";
 
 export enum ESignInSteps {
   EMAIL = "EMAIL",
@@ -39,79 +39,87 @@ export const SignInRoot = observer(() => {
     config: { envConfig },
   } = useApplication();
 
-  const isOAuthEnabled = envConfig && (envConfig.google_client_id || envConfig.github_client_id);
+  const isOAuthEnabled =
+    envConfig &&
+    (envConfig.google_client_id ||
+      envConfig.github_client_id ||
+      (envConfig.oidc_client_id && envConfig.oidc_url_authorize));
 
   return (
     <>
-      <div className="mx-auto flex flex-col">
-        <>
-          {signInStep === ESignInSteps.EMAIL && (
-            <EmailForm
-              handleStepChange={(step) => setSignInStep(step)}
-              updateEmail={(newEmail) => setEmail(newEmail)}
-            />
-          )}
-          {signInStep === ESignInSteps.PASSWORD && (
-            <PasswordForm
-              email={email}
-              updateEmail={(newEmail) => setEmail(newEmail)}
-              handleStepChange={(step) => setSignInStep(step)}
-              handleEmailClear={() => {
-                setEmail("");
-                setSignInStep(ESignInSteps.EMAIL);
-              }}
-              handleSignInRedirection={handleRedirection}
-            />
-          )}
-          {signInStep === ESignInSteps.SET_PASSWORD_LINK && (
-            <SetPasswordLink email={email} updateEmail={(newEmail) => setEmail(newEmail)} />
-          )}
-          {signInStep === ESignInSteps.USE_UNIQUE_CODE_FROM_PASSWORD && (
-            <UniqueCodeForm
-              email={email}
-              updateEmail={(newEmail) => setEmail(newEmail)}
-              handleStepChange={(step) => setSignInStep(step)}
-              handleSignInRedirection={handleRedirection}
-              submitButtonLabel="Go to workspace"
-              showTermsAndConditions
-              updateUserOnboardingStatus={(value) => setIsOnboarded(value)}
-              handleEmailClear={() => {
-                setEmail("");
-                setSignInStep(ESignInSteps.EMAIL);
-              }}
-            />
-          )}
-          {signInStep === ESignInSteps.UNIQUE_CODE && (
-            <UniqueCodeForm
-              email={email}
-              updateEmail={(newEmail) => setEmail(newEmail)}
-              handleStepChange={(step) => setSignInStep(step)}
-              handleSignInRedirection={handleRedirection}
-              updateUserOnboardingStatus={(value) => setIsOnboarded(value)}
-              handleEmailClear={() => {
-                setEmail("");
-                setSignInStep(ESignInSteps.EMAIL);
-              }}
-            />
-          )}
-          {signInStep === ESignInSteps.OPTIONAL_SET_PASSWORD && (
-            <OptionalSetPasswordForm
-              email={email}
-              handleStepChange={(step) => setSignInStep(step)}
-              handleSignInRedirection={handleRedirection}
-              isOnboarded={isOnboarded}
-            />
-          )}
-          {signInStep === ESignInSteps.CREATE_PASSWORD && (
-            <CreatePasswordForm
-              email={email}
-              handleStepChange={(step) => setSignInStep(step)}
-              handleSignInRedirection={handleRedirection}
-              isOnboarded={isOnboarded}
-            />
-          )}
-        </>
-      </div>
+      {envConfig?.oidc_auto ? (
+        <></>
+      ) : (
+        <div className="mx-auto flex flex-col">
+          <>
+            {signInStep === ESignInSteps.EMAIL && (
+              <EmailForm
+                handleStepChange={(step) => setSignInStep(step)}
+                updateEmail={(newEmail) => setEmail(newEmail)}
+              />
+            )}
+            {signInStep === ESignInSteps.PASSWORD && (
+              <PasswordForm
+                email={email}
+                updateEmail={(newEmail) => setEmail(newEmail)}
+                handleStepChange={(step) => setSignInStep(step)}
+                handleEmailClear={() => {
+                  setEmail("");
+                  setSignInStep(ESignInSteps.EMAIL);
+                }}
+                handleSignInRedirection={handleRedirection}
+              />
+            )}
+            {signInStep === ESignInSteps.SET_PASSWORD_LINK && (
+              <SetPasswordLink email={email} updateEmail={(newEmail) => setEmail(newEmail)} />
+            )}
+            {signInStep === ESignInSteps.USE_UNIQUE_CODE_FROM_PASSWORD && (
+              <UniqueCodeForm
+                email={email}
+                updateEmail={(newEmail) => setEmail(newEmail)}
+                handleStepChange={(step) => setSignInStep(step)}
+                handleSignInRedirection={handleRedirection}
+                submitButtonLabel="Go to workspace"
+                showTermsAndConditions
+                updateUserOnboardingStatus={(value) => setIsOnboarded(value)}
+                handleEmailClear={() => {
+                  setEmail("");
+                  setSignInStep(ESignInSteps.EMAIL);
+                }}
+              />
+            )}
+            {signInStep === ESignInSteps.UNIQUE_CODE && (
+              <UniqueCodeForm
+                email={email}
+                updateEmail={(newEmail) => setEmail(newEmail)}
+                handleStepChange={(step) => setSignInStep(step)}
+                handleSignInRedirection={handleRedirection}
+                updateUserOnboardingStatus={(value) => setIsOnboarded(value)}
+                handleEmailClear={() => {
+                  setEmail("");
+                  setSignInStep(ESignInSteps.EMAIL);
+                }}
+              />
+            )}
+            {signInStep === ESignInSteps.OPTIONAL_SET_PASSWORD && (
+              <OptionalSetPasswordForm
+                email={email}
+                handleStepChange={(step) => setSignInStep(step)}
+                handleSignInRedirection={handleRedirection}
+                isOnboarded={isOnboarded}
+              />
+            )}
+            {signInStep === ESignInSteps.CREATE_PASSWORD && (
+              <CreatePasswordForm
+                email={email}
+                handleStepChange={(step) => setSignInStep(step)}
+                handleSignInRedirection={handleRedirection}
+                isOnboarded={isOnboarded}
+              />
+            )}
+          </>
+        </div>
+      )}
       {isOAuthEnabled && !OAUTH_HIDDEN_STEPS.includes(signInStep) && (
         <OAuthOptions handleSignInRedirection={handleRedirection} />
       )}

--- a/web/components/account/sign-in-forms/root.tsx
+++ b/web/components/account/sign-in-forms/root.tsx
@@ -51,73 +51,71 @@ export const SignInRoot = observer(() => {
         <></>
       ) : (
         <div className="mx-auto flex flex-col">
-          <>
-            {signInStep === ESignInSteps.EMAIL && (
-              <EmailForm
-                handleStepChange={(step) => setSignInStep(step)}
-                updateEmail={(newEmail) => setEmail(newEmail)}
-              />
-            )}
-            {signInStep === ESignInSteps.PASSWORD && (
-              <PasswordForm
-                email={email}
-                updateEmail={(newEmail) => setEmail(newEmail)}
-                handleStepChange={(step) => setSignInStep(step)}
-                handleEmailClear={() => {
-                  setEmail("");
-                  setSignInStep(ESignInSteps.EMAIL);
-                }}
-                handleSignInRedirection={handleRedirection}
-              />
-            )}
-            {signInStep === ESignInSteps.SET_PASSWORD_LINK && (
-              <SetPasswordLink email={email} updateEmail={(newEmail) => setEmail(newEmail)} />
-            )}
-            {signInStep === ESignInSteps.USE_UNIQUE_CODE_FROM_PASSWORD && (
-              <UniqueCodeForm
-                email={email}
-                updateEmail={(newEmail) => setEmail(newEmail)}
-                handleStepChange={(step) => setSignInStep(step)}
-                handleSignInRedirection={handleRedirection}
-                submitButtonLabel="Go to workspace"
-                showTermsAndConditions
-                updateUserOnboardingStatus={(value) => setIsOnboarded(value)}
-                handleEmailClear={() => {
-                  setEmail("");
-                  setSignInStep(ESignInSteps.EMAIL);
-                }}
-              />
-            )}
-            {signInStep === ESignInSteps.UNIQUE_CODE && (
-              <UniqueCodeForm
-                email={email}
-                updateEmail={(newEmail) => setEmail(newEmail)}
-                handleStepChange={(step) => setSignInStep(step)}
-                handleSignInRedirection={handleRedirection}
-                updateUserOnboardingStatus={(value) => setIsOnboarded(value)}
-                handleEmailClear={() => {
-                  setEmail("");
-                  setSignInStep(ESignInSteps.EMAIL);
-                }}
-              />
-            )}
-            {signInStep === ESignInSteps.OPTIONAL_SET_PASSWORD && (
-              <OptionalSetPasswordForm
-                email={email}
-                handleStepChange={(step) => setSignInStep(step)}
-                handleSignInRedirection={handleRedirection}
-                isOnboarded={isOnboarded}
-              />
-            )}
-            {signInStep === ESignInSteps.CREATE_PASSWORD && (
-              <CreatePasswordForm
-                email={email}
-                handleStepChange={(step) => setSignInStep(step)}
-                handleSignInRedirection={handleRedirection}
-                isOnboarded={isOnboarded}
-              />
-            )}
-          </>
+          {signInStep === ESignInSteps.EMAIL && (
+            <EmailForm
+              handleStepChange={(step) => setSignInStep(step)}
+              updateEmail={(newEmail) => setEmail(newEmail)}
+            />
+          )}
+          {signInStep === ESignInSteps.PASSWORD && (
+            <PasswordForm
+              email={email}
+              updateEmail={(newEmail) => setEmail(newEmail)}
+              handleStepChange={(step) => setSignInStep(step)}
+              handleEmailClear={() => {
+                setEmail("");
+                setSignInStep(ESignInSteps.EMAIL);
+              }}
+              handleSignInRedirection={handleRedirection}
+            />
+          )}
+          {signInStep === ESignInSteps.SET_PASSWORD_LINK && (
+            <SetPasswordLink email={email} updateEmail={(newEmail) => setEmail(newEmail)} />
+          )}
+          {signInStep === ESignInSteps.USE_UNIQUE_CODE_FROM_PASSWORD && (
+            <UniqueCodeForm
+              email={email}
+              updateEmail={(newEmail) => setEmail(newEmail)}
+              handleStepChange={(step) => setSignInStep(step)}
+              handleSignInRedirection={handleRedirection}
+              submitButtonLabel="Go to workspace"
+              showTermsAndConditions
+              updateUserOnboardingStatus={(value) => setIsOnboarded(value)}
+              handleEmailClear={() => {
+                setEmail("");
+                setSignInStep(ESignInSteps.EMAIL);
+              }}
+            />
+          )}
+          {signInStep === ESignInSteps.UNIQUE_CODE && (
+            <UniqueCodeForm
+              email={email}
+              updateEmail={(newEmail) => setEmail(newEmail)}
+              handleStepChange={(step) => setSignInStep(step)}
+              handleSignInRedirection={handleRedirection}
+              updateUserOnboardingStatus={(value) => setIsOnboarded(value)}
+              handleEmailClear={() => {
+                setEmail("");
+                setSignInStep(ESignInSteps.EMAIL);
+              }}
+            />
+          )}
+          {signInStep === ESignInSteps.OPTIONAL_SET_PASSWORD && (
+            <OptionalSetPasswordForm
+              email={email}
+              handleStepChange={(step) => setSignInStep(step)}
+              handleSignInRedirection={handleRedirection}
+              isOnboarded={isOnboarded}
+            />
+          )}
+          {signInStep === ESignInSteps.CREATE_PASSWORD && (
+            <CreatePasswordForm
+              email={email}
+              handleStepChange={(step) => setSignInStep(step)}
+              handleSignInRedirection={handleRedirection}
+              isOnboarded={isOnboarded}
+            />
+          )}
         </div>
       )}
       {isOAuthEnabled && !OAUTH_HIDDEN_STEPS.includes(signInStep) && (

--- a/web/components/instance/oidc-config-form.tsx
+++ b/web/components/instance/oidc-config-form.tsx
@@ -262,7 +262,7 @@ export const InstanceOidcConfigForm: FC<IInstanceOidcConfigForm> = (props) => {
           <ToggleSwitch
             value={Boolean(parseInt(oidcAuto))}
             onChange={() => {
-              Boolean(parseInt(oidcAuto)) === true ? updateConfig("OIDC_AUTO", "0") : updateConfig("OIDC_AUTO", "1");
+              Boolean(parseInt(oidcAuto)) ? updateConfig("OIDC_AUTO", "0") : updateConfig("OIDC_AUTO", "1");
             }}
             size="sm"
             disabled={isSubmittingAuto}

--- a/web/components/instance/oidc-config-form.tsx
+++ b/web/components/instance/oidc-config-form.tsx
@@ -1,0 +1,274 @@
+import { FC, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { Copy, Eye, EyeOff } from "lucide-react";
+// ui
+import { Button, Input, ToggleSwitch } from "@plane/ui";
+// types
+import { IFormattedInstanceConfiguration } from "@plane/types";
+// hooks
+import { useApplication } from "hooks/store";
+import useToast from "hooks/use-toast";
+
+export interface IInstanceOidcConfigForm {
+  config: IFormattedInstanceConfiguration;
+  updateConfig: (
+    key: "ENABLE_SIGNUP" | "ENABLE_MAGIC_LINK_LOGIN" | "ENABLE_EMAIL_PASSWORD" | "OIDC_AUTO",
+    value: string
+  ) => Promise<void>;
+  isSubmittingAuto: boolean;
+}
+
+export interface OidcConfigFormValues {
+  OIDC_URL_AUTHORIZATION: string;
+  OIDC_URL_TOKEN: string;
+  OIDC_URL_USERINFO: string;
+  OIDC_CLIENT_ID: string;
+  OIDC_CLIENT_SECRET: string;
+  OIDC_URL_ENDSESSION?: string;
+}
+
+export const InstanceOidcConfigForm: FC<IInstanceOidcConfigForm> = (props) => {
+  const { config, updateConfig, isSubmittingAuto } = props;
+  // states
+  const [showPassword, setShowPassword] = useState(false);
+  // store hooks
+  const { instance: instanceStore } = useApplication();
+  // toast
+  const { setToastAlert } = useToast();
+  // form data
+  const {
+    handleSubmit,
+    control,
+    formState: { errors, isSubmitting },
+  } = useForm<OidcConfigFormValues>({
+    defaultValues: {
+      OIDC_URL_AUTHORIZATION: config["OIDC_URL_AUTHORIZATION"],
+      OIDC_URL_TOKEN: config["OIDC_URL_TOKEN"],
+      OIDC_URL_USERINFO: config["OIDC_URL_USERINFO"],
+      OIDC_URL_ENDSESSION: config["OIDC_URL_ENDSESSION"],
+      OIDC_CLIENT_ID: config["OIDC_CLIENT_ID"],
+      OIDC_CLIENT_SECRET: config["OIDC_CLIENT_SECRET"],
+    },
+  });
+
+  const oidcAuto = config.OIDC_AUTO ?? "0";
+
+  const onSubmit = async (formData: OidcConfigFormValues) => {
+    const payload: Partial<OidcConfigFormValues> = { ...formData };
+
+    await instanceStore
+      .updateInstanceConfigurations(payload)
+      .then(() =>
+        setToastAlert({
+          title: "Success",
+          type: "success",
+          message: "OpenID Connect Configuration Settings updated successfully",
+        })
+      )
+      .catch((err) => console.error(err));
+  };
+
+  const originURL = typeof window !== "undefined" ? window.location.origin : "";
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="grid-col grid w-full grid-cols-1 justify-between gap-x-12 gap-y-8 lg:grid-cols-3">
+        <div className="flex flex-col gap-1">
+          <h4 className="text-sm">Authorization URL</h4>
+          <Controller
+            control={control}
+            name="OIDC_URL_AUTHORIZATION"
+            render={({ field: { value, onChange, ref } }) => (
+              <Input
+                id="OIDC_URL_AUTHORIZATION"
+                name="OIDC_URL_AUTHORIZATION"
+                type="text"
+                value={value}
+                onChange={onChange}
+                ref={ref}
+                hasError={Boolean(errors.OIDC_URL_AUTHORIZATION)}
+                placeholder="https://idp.your-company.com/o/authorize/"
+                className="w-full rounded-md font-medium"
+              />
+            )}
+          />
+          <p className="text-xs text-custom-text-400">You will get this from your Identity Provider.</p>
+        </div>
+        <div className="flex flex-col gap-1">
+          <h4 className="text-sm">Token URL</h4>
+          <Controller
+            control={control}
+            name="OIDC_URL_TOKEN"
+            render={({ field: { value, onChange, ref } }) => (
+              <Input
+                id="OIDC_URL_TOKEN"
+                name="OIDC_URL_TOKEN"
+                type="text"
+                value={value}
+                onChange={onChange}
+                ref={ref}
+                hasError={Boolean(errors.OIDC_URL_TOKEN)}
+                placeholder="https://idp.your-company.com/o/token/"
+                className="w-full rounded-md font-medium"
+              />
+            )}
+          />
+          <p className="text-xs text-custom-text-400">You will get this from your Identity Provider.</p>
+        </div>
+        <div className="flex flex-col gap-1">
+          <h4 className="text-sm">Userinfo URL</h4>
+          <Controller
+            control={control}
+            name="OIDC_URL_USERINFO"
+            render={({ field: { value, onChange, ref } }) => (
+              <Input
+                id="OIDC_URL_USERINFO"
+                name="OIDC_URL_USERINFO"
+                type="text"
+                value={value}
+                onChange={onChange}
+                ref={ref}
+                hasError={Boolean(errors.OIDC_URL_USERINFO)}
+                placeholder="https://idp.your-company.com/o/token/"
+                className="w-full rounded-md font-medium"
+              />
+            )}
+          />
+          <p className="text-xs text-custom-text-400">You will get this from your Identity Provider.</p>
+        </div>
+        <div className="flex flex-col gap-1">
+          <h4 className="text-sm">Client ID</h4>
+          <Controller
+            control={control}
+            name="OIDC_CLIENT_ID"
+            render={({ field: { value, onChange, ref } }) => (
+              <Input
+                id="OIDC_CLIENT_ID"
+                name="OIDC_CLIENT_ID"
+                type="text"
+                value={value}
+                onChange={onChange}
+                ref={ref}
+                hasError={Boolean(errors.OIDC_CLIENT_ID)}
+                placeholder="70a44354520df8bd9bcd"
+                className="w-full rounded-md font-medium"
+              />
+            )}
+          />
+          <p className="text-xs text-custom-text-400">You will get this from your Identity Provider.</p>
+        </div>
+        <div className="flex flex-col gap-1">
+          <h4 className="text-sm">Client secret</h4>
+          <div className="relative">
+            <Controller
+              control={control}
+              name="OIDC_CLIENT_SECRET"
+              render={({ field: { value, onChange, ref } }) => (
+                <Input
+                  id="OIDC_CLIENT_SECRET"
+                  name="OIDC_CLIENT_SECRET"
+                  type={showPassword ? "text" : "password"}
+                  value={value}
+                  onChange={onChange}
+                  ref={ref}
+                  hasError={Boolean(errors.OIDC_CLIENT_SECRET)}
+                  placeholder="9b0050f94ec1b744e32ce79ea4ffacd40d4119cb"
+                  className="w-full rounded-md !pr-10 font-medium"
+                />
+              )}
+            />
+            {showPassword ? (
+              <button
+                className="absolute right-3 top-2.5 flex items-center justify-center text-custom-text-400"
+                onClick={() => setShowPassword(false)}
+              >
+                <EyeOff className="h-4 w-4" />
+              </button>
+            ) : (
+              <button
+                className="absolute right-3 top-2.5 flex items-center justify-center text-custom-text-400"
+                onClick={() => setShowPassword(true)}
+              >
+                <Eye className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+
+          <p className="text-xs text-custom-text-400">You will get this from your Identity Provider.</p>
+        </div>
+        <div className="flex flex-col gap-1">
+          <h4 className="text-sm">Redirect URL</h4>
+          <Button
+            variant="neutral-primary"
+            className="flex items-center justify-between py-2"
+            onClick={() => {
+              navigator.clipboard.writeText(originURL + "/*");
+              setToastAlert({
+                message: "The Redirect URL has been successfully copied to your clipboard",
+                type: "success",
+                title: "Copied to clipboard",
+              });
+            }}
+          >
+            <p className="text-sm font-medium">{originURL + "/*"}</p>
+            <Copy size={18} color="#B9B9B9" />
+          </Button>
+          <p className="text-xs text-custom-text-400">
+            We will auto-generate this. Paste this into the Redirect or Authorization callback URL field of your
+            Identity Provider settings.
+          </p>
+        </div>
+        <div className="flex flex-col gap-1">
+          <h4 className="text-sm">Logout URL (Optional)</h4>
+          <Controller
+            control={control}
+            name="OIDC_URL_ENDSESSION"
+            render={({ field: { value, onChange, ref } }) => (
+              <Input
+                id="OIDC_URL_ENDSESSION"
+                name="OIDC_URL_ENDSESSION"
+                type="text"
+                value={value}
+                onChange={onChange}
+                ref={ref}
+                hasError={Boolean(errors.OIDC_URL_ENDSESSION)}
+                placeholder="https://idp.your-company.com/o/end-session/"
+                className="w-full rounded-md font-medium"
+              />
+            )}
+          />
+          <p className="text-xs text-custom-text-400">
+            Instead of redirecting to the plane login page it will redirect to your Identity Provider using the Logout
+            URL provided by your Identity Provider.
+          </p>
+        </div>
+      </div>
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center">
+          <Button variant="primary" onClick={handleSubmit(onSubmit)} loading={isSubmitting}>
+            {isSubmitting ? "Saving..." : "Save changes"}
+          </Button>
+        </div>
+      </div>
+      <div className="mr-4 flex items-center gap-14">
+        <div className="grow">
+          <div className="text-sm font-medium text-custom-text-100">Automatically use OpenID Connect to SignIn</div>
+          <div className="text-xs font-normal text-custom-text-300">
+            Toggling this on will automatically redirect the user to your Identity Provider using OpenID Connect to sign
+            in if they arent authenticated.
+          </div>
+        </div>
+        <div className={`shrink-0 ${isSubmittingAuto && "opacity-70"}`}>
+          <ToggleSwitch
+            value={Boolean(parseInt(oidcAuto))}
+            onChange={() => {
+              Boolean(parseInt(oidcAuto)) === true ? updateConfig("OIDC_AUTO", "0") : updateConfig("OIDC_AUTO", "1");
+            }}
+            size="sm"
+            disabled={isSubmittingAuto}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/web/components/instance/sidebar-dropdown.tsx
+++ b/web/components/instance/sidebar-dropdown.tsx
@@ -30,6 +30,7 @@ export const InstanceSidebarDropdown = observer(() => {
   const router = useRouter();
   // store hooks
   const {
+    config: { envConfig },
     theme: { sidebarCollapsed },
     router: { workspaceSlug },
   } = useApplication();
@@ -50,7 +51,8 @@ export const InstanceSidebarDropdown = observer(() => {
       .then(() => {
         mutate("CURRENT_USER_DETAILS", null);
         setTheme("system");
-        router.push("/");
+        if (envConfig?.oidc_url_endsession) router.push(envConfig.oidc_url_endsession);
+        else router.push("/");
       })
       .catch(() =>
         setToastAlert({

--- a/web/components/workspace/sidebar-dropdown.tsx
+++ b/web/components/workspace/sidebar-dropdown.tsx
@@ -56,6 +56,7 @@ export const WorkspaceSidebarDropdown = observer(() => {
   const { workspaceSlug } = router.query;
   // store hooks
   const {
+    config: { envConfig },
     theme: { sidebarCollapsed },
     eventTracker: { setTrackElement },
   } = useApplication();
@@ -75,7 +76,8 @@ export const WorkspaceSidebarDropdown = observer(() => {
       .then(() => {
         mutate("CURRENT_USER_DETAILS", null);
         setTheme("system");
-        router.push("/");
+        if (envConfig?.oidc_url_endsession) router.push(envConfig.oidc_url_endsession);
+        else router.push("/");
       })
       .catch(() =>
         setToastAlert({

--- a/web/layouts/settings-layout/profile/sidebar.tsx
+++ b/web/layouts/settings-layout/profile/sidebar.tsx
@@ -64,6 +64,7 @@ export const ProfileLayoutSidebar = observer(() => {
   const { setToastAlert } = useToast();
   // store hooks
   const {
+    config: { envConfig },
     theme: { sidebarCollapsed, toggleSidebar },
   } = useApplication();
   const { currentUser, currentUserSettings, signOut } = useUser();
@@ -84,7 +85,8 @@ export const ProfileLayoutSidebar = observer(() => {
       .then(() => {
         mutate("CURRENT_USER_DETAILS", null);
         setTheme("system");
-        router.push("/");
+        if (envConfig?.oidc_url_endsession) router.push(envConfig.oidc_url_endsession);
+        else router.push("/");
       })
       .catch(() =>
         setToastAlert({

--- a/web/pages/god-mode/authorization.tsx
+++ b/web/pages/god-mode/authorization.tsx
@@ -14,6 +14,7 @@ import useToast from "hooks/use-toast";
 import { Loader, ToggleSwitch } from "@plane/ui";
 // components
 import { InstanceGithubConfigForm, InstanceGoogleConfigForm } from "components/instance";
+import { InstanceOidcConfigForm } from "components/instance/oidc-config-form";
 
 const InstanceAdminAuthorizationPage: NextPageWithLayout = observer(() => {
   // store
@@ -34,7 +35,7 @@ const InstanceAdminAuthorizationPage: NextPageWithLayout = observer(() => {
   // const enableEmailPassword = formattedConfig?.ENABLE_EMAIL_PASSWORD ?? "0";
 
   const updateConfig = async (
-    key: "ENABLE_SIGNUP" | "ENABLE_MAGIC_LINK_LOGIN" | "ENABLE_EMAIL_PASSWORD",
+    key: "ENABLE_SIGNUP" | "ENABLE_MAGIC_LINK_LOGIN" | "ENABLE_EMAIL_PASSWORD" | "OIDC_AUTO",
     value: string
   ) => {
     setIsSubmitting(true);
@@ -162,6 +163,14 @@ const InstanceAdminAuthorizationPage: NextPageWithLayout = observer(() => {
               </div>
               <div className="px-2 py-6">
                 <InstanceGithubConfigForm config={formattedConfig} />
+              </div>
+            </div>
+            <div className="w-full">
+              <div className="flex items-center justify-between border-b border-custom-border-100 py-2">
+                <span className="text-lg font-medium tracking-tight">OpenID Connect</span>
+              </div>
+              <div className="px-2 py-6">
+                <InstanceOidcConfigForm config={formattedConfig} updateConfig={updateConfig} isSubmittingAuto={isSubmitting} />
               </div>
             </div>
           </div>

--- a/web/services/auth.service.ts
+++ b/web/services/auth.service.ts
@@ -96,6 +96,18 @@ export class AuthService extends APIService {
       });
   }
 
+  async oidcAuth(data: any) {
+    return this.post("/api/oidc-auth/", data, { headers: {} })
+      .then((response) => {
+        this.setAccessToken(response?.data?.access_token);
+        this.setRefreshToken(response?.data?.refresh_token);
+        return response?.data;
+      })
+      .catch((error) => {
+        throw error?.response?.data;
+      });
+  }
+
   async generateUniqueCode(data: { email: string }): Promise<any> {
     return this.post("/api/magic-generate/", data, { headers: {} })
       .then((response) => response?.data)

--- a/web/services/auth.service.ts
+++ b/web/services/auth.service.ts
@@ -96,7 +96,7 @@ export class AuthService extends APIService {
       });
   }
 
-  async oidcAuth(data: any) {
+  oidcAuth(data: { credential: string, clientId: string }) {
     return this.post("/api/oidc-auth/", data, { headers: {} })
       .then((response) => {
         this.setAccessToken(response?.data?.access_token);


### PR DESCRIPTION
This PR is a replica of https://github.com/makeplane/plane/pull/3341 because a merge was not allowed.


This PR closes https://github.com/makeplane/plane/pull/1319 because it was more work to pull the current develop branch into the old branch than to just rebase the code from it into this one.
I tried to clean up the commit as good as possible.
This PR enables Authentication via OpenID Connect for Self-Hosted Instances. It can be configured via the Environment Variables (here it is also possible to do a Autodiscovery for the Endpoints if you set the issuer) or via the new God-Mode.
It also enables Auto-SignIn for OIDC so that the users don't have to click anything and are redirected directly if they aren't signed in yet. This can also be switched on or off via the God-Mode Interface.
Futhermore it also implements to be logged out to the End-Session Endpoint of the OpenID Provider.

It matches the user based on the email address. If a new user is created the username is set based on the preferred_username from the Identity Provider.

It has proven to work with Authentik and Keycloak.